### PR TITLE
Extract card component CSS and align heading hierarchy with the designs

### DIFF
--- a/app/javascript/css/application.css
+++ b/app/javascript/css/application.css
@@ -1,3 +1,4 @@
 @import "tailwindcss/base";
 @import "tailwindcss/components";
+@import "./components.css";
 @import "tailwindcss/utilities";

--- a/app/javascript/css/components.css
+++ b/app/javascript/css/components.css
@@ -53,9 +53,9 @@
 }
 
 h4 {
-    @apply font-medium text-sm text-black leading-4;
+    @apply font-medium text-sm text-blue-600 leading-4;
 }
 
 p {
-    @apply text-sm text-gray-600 mb-2 text-sm text-gray-600 leading-5
+    @apply text-sm text-gray-700 mb-2 text-sm leading-5
 }

--- a/app/javascript/css/components.css
+++ b/app/javascript/css/components.css
@@ -59,3 +59,19 @@ h4 {
 p {
     @apply text-sm text-gray-700 mb-2 text-sm leading-5
 }
+
+button {
+    @apply px-4 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-blue-600 rounded-md shadow-sm
+}
+
+button:hover {
+    @apply bg-blue-500
+}
+
+button:active {
+    @apply bg-blue-700
+}
+
+button:focus {
+    @apply outline-none shadow-outline-blue border-blue-700
+}

--- a/app/javascript/css/components.css
+++ b/app/javascript/css/components.css
@@ -60,18 +60,14 @@ p {
     @apply text-sm text-gray-700 mb-2 text-sm leading-5
 }
 
-button {
+.button {
     @apply px-4 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-blue-600 rounded-md shadow-sm
 }
 
-button:hover {
+.button:hover {
     @apply bg-blue-500
 }
 
-button:active {
+.button:active {
     @apply bg-blue-700
-}
-
-button:focus {
-    @apply outline-none shadow-outline-blue border-blue-700
 }

--- a/app/javascript/css/components.css
+++ b/app/javascript/css/components.css
@@ -1,0 +1,61 @@
+.big-title {
+    @apply text-2xl font-bold tracking-tight leading-tight;
+}
+
+.big-subtitle {
+    @apply tracking-tight leading-tight mt-2;
+}
+
+@screen sm {
+    .big-title {
+        @apply text-4xl;
+    }
+
+    .big-subtitle {
+        @apply text-2xl;
+    }
+}
+
+.small-title {
+    @apply text-lg leading-6 font-medium text-gray-900 ml-4 mt-4;
+}
+
+.card {
+    @apply shadow bg-white border border-gray-200 mb-6;
+}
+
+.card .card-inner {
+    @apply px-4 py-4;
+}
+
+@screen sm {
+    .card {
+        @apply rounded-md;
+    }
+
+    .card .card-inner {
+        @apply px-6;
+    }
+}
+
+/* Card heading */
+.card h2 {
+    @apply text-xl leading-5 font-medium text-blue-600 truncate underline ml-0 mt-0;
+}
+
+/* Card subheading */
+.card h3 {
+    @apply mt-1 text-gray-600;
+}
+
+.card .card-section {
+    @apply mt-4;
+}
+
+.card .card-section h3 {
+    @apply font-medium text-sm text-black;
+}
+
+.card .card-section p {
+    @apply text-sm text-gray-600 mb-2 text-sm text-gray-600
+}

--- a/app/javascript/css/components.css
+++ b/app/javascript/css/components.css
@@ -40,22 +40,22 @@
 
 /* Card heading */
 .card h2 {
-    @apply text-xl leading-5 font-medium text-blue-600 truncate underline ml-0 mt-0;
+    @apply text-xl leading-6 font-medium text-blue-600 truncate underline ml-0 mt-0;
 }
 
 /* Card subheading */
 .card h3 {
-    @apply mt-1 text-gray-600;
+    @apply mt-1 leading-5 text-gray-600;
 }
 
 .card .card-section {
     @apply mt-4;
 }
 
-.card .card-section h3 {
-    @apply font-medium text-sm text-black;
+h4 {
+    @apply font-medium text-sm text-black leading-4;
 }
 
-.card .card-section p {
-    @apply text-sm text-gray-600 mb-2 text-sm text-gray-600
+p {
+    @apply text-sm text-gray-600 mb-2 text-sm text-gray-600 leading-5
 }

--- a/app/views/papers/_paper.html.erb
+++ b/app/views/papers/_paper.html.erb
@@ -1,28 +1,24 @@
-<li class="shadow bg-white border border-gray-200 mb-6 sm:rounded-md">
-    <div class="px-4 py-4 sm:px-6">
-        <h2 class="text-xl leading-5 font-medium text-blue-600 truncate underline">
+<li class="card">
+    <div class="card-inner">
+        <h2>
             <%= link_to paper.title, paper.link, rel: "nofollow" %>
         </h2>
-        <h3 class="mt-1 text-gray-600"><%= link_to paper.authors %>, <%= paper.affiliations %></h3>
+        <h3><%= link_to paper.authors %>, <%= paper.affiliations %></h3>
 
-        <p class="mt-4">
-            <h3 class="font-medium text-sm">Molecular targets</h3>
-            <div class="text-sm text-gray-600">
+        <div class="card-section">
+            <h3>Molecular targets</h3>
+            <p>
                 <%= paper.target %>
-            </div>
-        </p>
-
-        <div class="mt-4">
-            <h3 class="text-sm font-medium ">Key Findings</h3>
-            <div class="text-sm text-gray-600">
-                <%= simple_format paper.key_finding, class: 'mb-2' %>
-            </div>
+            </p>
         </div>
-        <div class="mt-4">
-            <h3 class="text-sm font-medium ">Context</h3>
-            <div class="text-sm text-gray-600">
-                <%= simple_format paper.context, class: 'mb-2' %>
-            </div>
+
+        <div class="card-section">
+            <h3>Key Findings</h3>
+            <%= simple_format paper.key_finding %>
+        </div>
+        <div class="card-section">
+            <h3>Context</h3>
+            <%= simple_format paper.context %>
         </div>
     </div>
 </li>

--- a/app/views/papers/_paper.html.erb
+++ b/app/views/papers/_paper.html.erb
@@ -6,18 +6,18 @@
         <h3><%= link_to paper.authors %>, <%= paper.affiliations %></h3>
 
         <div class="card-section">
-            <h3>Molecular targets</h3>
+            <h4>Molecular targets</h4>
             <p>
                 <%= paper.target %>
             </p>
         </div>
 
         <div class="card-section">
-            <h3>Key Findings</h3>
+            <h4>Key Findings</h4>
             <%= simple_format paper.key_finding %>
         </div>
         <div class="card-section">
-            <h3>Context</h3>
+            <h4>Context</h4>
             <%= simple_format paper.context %>
         </div>
     </div>

--- a/app/views/papers/index.html.erb
+++ b/app/views/papers/index.html.erb
@@ -6,11 +6,7 @@
     </h1>
     <div class="ml-4 mt-4 flex-shrink-0">
       <span class="inline-flex">
-        <%= link_to "/submit" do %>
-          <button type="button" class="relative inline-flex items-center">
-            Submit another paper
-          </button>
-        <% end %>
+        <%= button_to "Submit another paper", "/submit", method: "get", class: "button relative inline-flex items-center" %>
       </span>
     </div>
   </div>

--- a/app/views/papers/index.html.erb
+++ b/app/views/papers/index.html.erb
@@ -1,9 +1,9 @@
 
 <div class="bg-white px-4 py-5 border-b border-gray-200 sm:px-6 mb-4">
   <div class="-ml-4 -mt-4 flex justify-between items-center flex-wrap sm:flex-no-wrap">
-    <h3 class="text-lg leading-6 font-medium text-gray-900 ml-4 mt-4">
+    <h1 class="small-title">
         COVID-19 Science Engine (Prototype)
-    </h3>
+    </h1>
     <div class="ml-4 mt-4 flex-shrink-0">
       <span class="inline-flex rounded-md shadow-sm">
         <%= link_to "/submit" do %>

--- a/app/views/papers/index.html.erb
+++ b/app/views/papers/index.html.erb
@@ -5,9 +5,9 @@
         COVID-19 Science Engine (Prototype)
     </h1>
     <div class="ml-4 mt-4 flex-shrink-0">
-      <span class="inline-flex rounded-md shadow-sm">
+      <span class="inline-flex">
         <%= link_to "/submit" do %>
-          <button type="button" class="relative inline-flex items-center px-4 py-2 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-blue-600 hover:bg-blue-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-700 active:bg-blue-700">
+          <button type="button" class="relative inline-flex items-center">
             Submit another paper
           </button>
         <% end %>


### PR DESCRIPTION
This is a first stab at using the tailwind PostCSS plugin to compose all the different CSS classes, as discussed in https://github.com/COVID-science-engine/crowdsourced-papers-prototype/issues/4

Rather than directly refer to a bunch of tailwind classes in the HTML, this uses the @apply directive to mix tailwind stuff into more useful CSS classes. It works with most classes, but not the ones with variants that use media queries.

https://tailwindcss.com/course/composing-utilities-with-apply explains how this works.

I'm planning to use this as a base for aligning the heading hierarchy with the [design system](https://www.figma.com/file/RtHSp2qSI9TJfzxjRmLCOj/Covid-Science-Engine---Design-System).
